### PR TITLE
Update libuv to v1.9.0

### DIFF
--- a/build/Microsoft.AspNetCore.Internal.libuv-Darwin.nuspec
+++ b/build/Microsoft.AspNetCore.Internal.libuv-Darwin.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>Microsoft.AspNetCore.Internal.libuv-Darwin</id>
-        <version>0.0.1-pre</version>
+        <version>0.0.1-ignored</version>
         <authors>Microsoft</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>libuv build package - Darwin</description>

--- a/build/Microsoft.AspNetCore.Internal.libuv-Linux.nuspec
+++ b/build/Microsoft.AspNetCore.Internal.libuv-Linux.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>Microsoft.AspNetCore.Internal.libuv-Linux</id>
-        <version>0.0.1-pre</version>
+        <version>0.0.1-ignored</version>
         <authors>Microsoft</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>libuv build package - Linux</description>

--- a/build/Microsoft.AspNetCore.Internal.libuv-Windows.nuspec
+++ b/build/Microsoft.AspNetCore.Internal.libuv-Windows.nuspec
@@ -2,10 +2,10 @@
 <package>
     <metadata>
         <id>Microsoft.AspNetCore.Internal.libuv-Windows</id>
-        <version>0.0.1-pre</version>
+        <version>0.0.1-ignored</version>
         <authors>Microsoft</authors>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>libuv build package - Window</description>
+        <description>libuv build package - Windows</description>
     </metadata>
     <files>
         <file src="contents\**" />

--- a/makefile.shade
+++ b/makefile.shade
@@ -67,7 +67,7 @@ var FULL_VERSION = '${PRODUCT_VERSION + "-" + E("DOTNET_BUILD_VERSION")}'
         var sources = string.Join(" ", sourceFiles);
 
         Exec(CLANG,
-            string.Format("{0} -fPIC -shared -o {1}  -I{2}/include -I{2}/src -Wall -Wextra -Wno-unused-parameter -g --std=gnu89 -pedantic -D_DARWIN_USE_64_BIT_INODE=1 -D_DARWIN_UNLIMITED_SELECT=1 -arch i386 -arch x86_64",
+            string.Format("{0} -lm -pthread -fPIC -shared -o {1}  -I{2}/include -I{2}/src -Wall -Wextra -Wno-unused-parameter -g --std=gnu89 -pedantic -D_DARWIN_USE_64_BIT_INODE=1 -D_DARWIN_UNLIMITED_SELECT=1 -D_BUILDING_UV_SHARED=1 -arch i386 -arch x86_64",
             sources, outputPath, libuvRoot));
     }
 
@@ -92,7 +92,7 @@ var FULL_VERSION = '${PRODUCT_VERSION + "-" + E("DOTNET_BUILD_VERSION")}'
         var sources = string.Join(" ", sourceFiles);
 
         Exec(CLANG,
-            string.Format("{0} -fPIC -shared -o {1}  -I{2}/include -I{2}/src -Wall -Wextra -Wno-unused-parameter -g --std=gnu89 -pedantic -D_GNU_SOURCE", sources, outputPath, libuvRoot));
+            string.Format("{0} -lm -pthread -ldl -lrt -fPIC -shared -o {1}  -I{2}/include -I{2}/src -Wall -Wextra -Wno-unused-parameter -Wstrict-aliasing -g --std=gnu89 -pedantic -D_GNU_SOURCE -D_BUILDING_UV_SHARED=1", sources, outputPath, libuvRoot));
     }
 
 #nuget-pack target='package' if='CanBuildForDarwin'

--- a/makefile.shade
+++ b/makefile.shade
@@ -1,4 +1,4 @@
-var PRODUCT_VERSION = '1.0.0'
+var PRODUCT_VERSION = '1.9.0'
 var AUTHORS='Microsoft Open Technologies, Inc.'
 
 use-standard-lifecycle

--- a/src/libuv/libuv.vcxproj
+++ b/src/libuv/libuv.vcxproj
@@ -85,6 +85,7 @@
     <ClCompile Include="..\..\submodules\libuv\src\win\process-stdio.c"/>
     <ClCompile Include="..\..\submodules\libuv\src\win\req.c"/>
     <ClCompile Include="..\..\submodules\libuv\src\win\signal.c"/>
+    <ClCompile Include="..\..\submodules\libuv\src\win\snprintf.c"/>
     <ClCompile Include="..\..\submodules\libuv\src\win\stream.c"/>
     <ClCompile Include="..\..\submodules\libuv\src\win\tcp.c"/>
     <ClCompile Include="..\..\submodules\libuv\src\win\tty.c"/>


### PR DESCRIPTION
- Match NuGet package versions with libuv version
- Update build scripts to match uv.gyp

https://github.com/dotnet/coreclr/issues/1466

@moozzyk 